### PR TITLE
Making the upgrade more specific

### DIFF
--- a/installation/install.sh
+++ b/installation/install.sh
@@ -38,7 +38,7 @@ gitman install --force
 ## | ---------------- install px4 dependencies ---------------- |
 
 $MY_PATH/../ros_packages/px4/Tools/setup/ubuntu.sh --no-nuttx --no-sim-tool
-sudo apt -y upgrade # this was needed after the first installation to fix the libignition-fuel-...
+sudo apt -y upgrade 'libignition-fuel-*' # this was needed after the first installation to fix the libignition-fuel-...
 
 ## | --------------------- install gazebo --------------------- |
 


### PR DESCRIPTION
Calling full system upgrade without even asking the user is a horrible idea.
Several rather difficult to set up things just got broken for me, since I specifically use selected versions of some software and I have to manually override some dependencies. I doubt that I am the only one in the wild who does this and this is a public repo.
I suggest this change - specifically upgrade what we need. Alternatively, remove the `-y`, so that the user is at least informed.