### PR TITLE
Fixing the 'just_flying' script 

### DIFF
--- a/example_tmux_scripts/just_flying_bare_tmux/just_flying.sh
+++ b/example_tmux_scripts/just_flying_bare_tmux/just_flying.sh
@@ -29,7 +29,7 @@ export UAV_NUMBER=$(shuf -i 1-30 -n 1);
 export UAV_NAME="uav${UAV_NUMBER}"
 
 # following commands will be executed first, in each window
-pre_input="export UAV_NAME="uav${UAV_NAME}"; export UAV_NUMBER=$UAV_NUMBER export RUN_TYPE=simulation; export UAV_TYPE=f550; export WORLD_NAME=simulation; export SENSORS='garmin_down'"
+pre_input="export UAV_NAME="${UAV_NAME}"; export UAV_NUMBER=$UAV_NUMBER export RUN_TYPE=simulation; export UAV_TYPE=f550; export WORLD_NAME=simulation; export SENSORS='garmin_down'"
 
 # define commands
 # 'name' 'command'

--- a/example_tmux_scripts/just_flying_bare_tmux/just_flying.sh
+++ b/example_tmux_scripts/just_flying_bare_tmux/just_flying.sh
@@ -26,9 +26,10 @@ PROJECT_NAME=just_flying
 SESSION_NAME=mav
 
 export UAV_NUMBER=$(shuf -i 1-30 -n 1);
+export UAV_NAME="uav${UAV_NUMBER}"
 
 # following commands will be executed first, in each window
-pre_input="export UAV_NAME="uav${UAV_NUMBER}"; export UAV_NUMBER=$UAV_NUMBER export RUN_TYPE=simulation; export UAV_TYPE=f550; export WORLD_NAME=simulation; export SENSORS='garmin_down'"
+pre_input="export UAV_NAME="uav${UAV_NAME}"; export UAV_NUMBER=$UAV_NUMBER export RUN_TYPE=simulation; export UAV_TYPE=f550; export WORLD_NAME=simulation; export SENSORS='garmin_down'"
 
 # define commands
 # 'name' 'command'


### PR DESCRIPTION
Discovered with @matemat13 at running the `just_flying.sh` script on a fresh install. The `UAV_NAME` variable inserted into some of the session commands was pre-filled with the hard-coded value from `.bashrc`, since the name randomization was ocurring after the variable was expanded. The UAV was not taking off, since the command went to e.g. `uav1` instead of the randomized `UAV_NAME`.